### PR TITLE
Support switching between USB host and device

### DIFF
--- a/src/SerialCDC_tusb.cpp
+++ b/src/SerialCDC_tusb.cpp
@@ -9,6 +9,7 @@
 
 #if SUPPORT_USB
 
+#include "TinyUsbInterface.h"
 #include "SerialCDC_tusb.h"
 
 #if CORE_USES_TINYUSB
@@ -27,18 +28,35 @@ SerialCDC::SerialCDC() noexcept
 
 void SerialCDC::Start(Pin p) noexcept
 {
+#if CFG_TUH_ENABLED
+	if (CoreUsbIsHostMode())
+	{
+		return;
+	}
+#endif
+	vBusPin = p;
 	while (!tud_inited()) { delay(10); }
 	running = true;
 }
 
 void SerialCDC::end() noexcept
 {
+#if CFG_TUH_ENABLED
+	if (CoreUsbIsHostMode())
+	{
+		return;
+	}
+#endif
 	running = false;
 }
 
 bool SerialCDC::IsConnected() const noexcept
 {
-	return tud_cdc_connected();
+	return
+#if CFG_TUH_ENABLED
+	!CoreUsbIsHostMode() &&
+#endif
+	tud_cdc_connected();
 }
 
 // Overridden virtual functions
@@ -49,36 +67,57 @@ bool SerialCDC::IsConnected() const noexcept
 // available() returned nonzero bit read() never read it. Now we check neither when reading.
 int SerialCDC::read() noexcept
 {
-    if (!running)
-    {
-    	return -1;
-    }
+	if (!running
+#if CFG_TUH_ENABLED
+	|| CoreUsbIsHostMode()
+#endif
+	)
+	{
+		return -1;
+	}
 
-    if (tud_cdc_available())
-    {
-        return tud_cdc_read_char();
-    }
-    return -1;
+	if (tud_cdc_available())
+	{
+		return tud_cdc_read_char();
+	}
+	return -1;
 }
 
 int SerialCDC::available() noexcept
 {
-    if (!running)
-    {
-    	return 0;
-    }
+	if (!running
+#if CFG_TUH_ENABLED
+	|| CoreUsbIsHostMode()
+#endif
+	)
+	{
+		return 0;
+	}
 
-    return tud_cdc_available();
+	return tud_cdc_available();
 }
 
 size_t SerialCDC::readBytes(char * _ecv_array buffer, size_t length) noexcept
 {
+	if (!running
+#if CFG_TUH_ENABLED
+	|| CoreUsbIsHostMode()
+#endif
+	)
+	{
+		return 0;
+	}
+
 	return tud_cdc_read (buffer, length);
 }
 
 void SerialCDC::flush() noexcept
 {
-	if (!running)
+	if (!running
+#if CFG_TUH_ENABLED
+	|| CoreUsbIsHostMode()
+#endif
+	)
 	{
 		return;
 	}
@@ -88,7 +127,11 @@ void SerialCDC::flush() noexcept
 
 size_t SerialCDC::canWrite() noexcept
 {
-	if (!running)
+	if (!running
+#if CFG_TUH_ENABLED
+	|| CoreUsbIsHostMode()
+#endif
+	)
 	{
 		return 0;
 	}
@@ -99,13 +142,23 @@ size_t SerialCDC::canWrite() noexcept
 // Write single character, blocking
 size_t SerialCDC::write(uint8_t c) noexcept
 {
+#if CFG_TUH_ENABLED
+	if (CoreUsbIsHostMode())
+	{
+		return 0;
+	}
+#endif
 	return write(&c, 1);
 }
 
 // Blocking write block
 size_t SerialCDC::write(const uint8_t *buf, size_t length) noexcept
 {
-	if (!running)
+	if (!running
+#if CFG_TUH_ENABLED
+	|| CoreUsbIsHostMode()
+#endif
+	)
 	{
 		return 0;
 	}

--- a/src/TinyUsbInterface.cpp
+++ b/src/TinyUsbInterface.cpp
@@ -279,13 +279,8 @@ static Pin UsbModeDetect;
 #endif
 
 // Call this to initialise the hardware
-#if CFG_TUH_ENABLED
 void CoreUsbInit(NvicPriority priority, Pin usbVbusDetect, Pin usbVbusOn, Pin usbModeSwitch, Pin usbModeDetect) noexcept
-#else
-void CoreUsbInit(NvicPriority priority) noexcept
-#endif
 {
-
 #if CFG_TUH_ENABLED
 	UsbVbusDetect = usbVbusDetect;
 	UsbVbusOn = usbVbusOn;
@@ -494,8 +489,17 @@ void CoreUsbStop()
 #if CFG_TUH_ENABLED
 	digitalWrite(UsbVbusOn, false);
 #endif
+
+#if SAME5x
+	NVIC_DisableIRQ(USB_0_IRQn);
+	NVIC_DisableIRQ(USB_1_IRQn);
+	NVIC_DisableIRQ(USB_2_IRQn);
+	NVIC_DisableIRQ(USB_3_IRQn);
+	USB->DEVICE.CTRLA.reg &= ~USB_CTRLA_ENABLE;
+#elif SAME70
 	NVIC_DisableIRQ((IRQn_Type)ID_USBHS);
 	USBHS->USBHS_CTRL &= ~USBHS_CTRL_USBE;
+#endif
 }
 
 #if RP2040		// RP2040 USB configuration has HID enabled by default

--- a/src/TinyUsbInterface.cpp
+++ b/src/TinyUsbInterface.cpp
@@ -350,17 +350,13 @@ bool CoreUsbSetHostMode(bool hostMode, const StringRef& reply)
 		return false;
 	}
 
-	if (hostMode && digitalRead(UsbVbusDetect))
+	if (!CoreUsbIsHostMode() && hostMode && digitalRead(UsbVbusDetect))
 	{
 		reply.printf("Unable to change to host mode, board plugged in to computer\n");
 		return false;
 	}
 
-	if (hostMode == CoreUsbIsHostMode())
-	{
-		reply.printf("Already in %s mode\n", hostMode ? "host" : "device");
-	}
-	else
+	if (hostMode != CoreUsbIsHostMode())
 	{
 		CoreUsbStop();
 		changingMode = true;

--- a/src/TinyUsbInterface.h
+++ b/src/TinyUsbInterface.h
@@ -23,12 +23,25 @@
 #define TINYUSBINTERFACE_H_INCLUDED
 
 #include <Core.h>
+#include <General/StringRef.h>
 
 #if SUPPORT_USB && CORE_USES_TINYUSB
+#include "tusb_option.h"
 
-void CoreUsbInit(NvicPriority priority) noexcept;							// call this to initialise the hardware
-extern "C" [[noreturn]] void CoreUsbDeviceTask(void* param) noexcept;		// this must be called by the USB task
-
+#if CFG_TUH_ENABLED
+void CoreUsbInit(NvicPriority priority, Pin usbVbusDetect = NoPin, Pin usbVbusOn = NoPin, Pin usbModeSwitch = NoPin, Pin usbModeDetect = NoPin) noexcept;	// call this to initialise the hardware
+bool CoreUsbSetHostMode(bool hostMode, const StringRef& reply);
+bool CoreUsbIsHostMode();
+#else
+void CoreUsbInit(NvicPriority priority) noexcept;	// call this to initialise the hardware
 #endif
+
+extern "C" [[noreturn]] void CoreUsbDeviceTask(void* param) noexcept;		// this must be called by the USB task
+void CoreUsbStop();
+
+#else
+#define CFG_TUH_ENABLED 0
+#endif
+
 
 #endif	// TINYUSBINTERFACE_H_INCLUDED

--- a/src/TinyUsbInterface.h
+++ b/src/TinyUsbInterface.h
@@ -28,16 +28,14 @@
 #if SUPPORT_USB && CORE_USES_TINYUSB
 #include "tusb_option.h"
 
-#if CFG_TUH_ENABLED
 void CoreUsbInit(NvicPriority priority, Pin usbVbusDetect = NoPin, Pin usbVbusOn = NoPin, Pin usbModeSwitch = NoPin, Pin usbModeDetect = NoPin) noexcept;	// call this to initialise the hardware
-bool CoreUsbSetHostMode(bool hostMode, const StringRef& reply);
-bool CoreUsbIsHostMode();
-#else
-void CoreUsbInit(NvicPriority priority) noexcept;	// call this to initialise the hardware
-#endif
-
 extern "C" [[noreturn]] void CoreUsbDeviceTask(void* param) noexcept;		// this must be called by the USB task
 void CoreUsbStop();
+
+#if CFG_TUH_ENABLED
+bool CoreUsbSetHostMode(bool hostMode, const StringRef& reply);
+bool CoreUsbIsHostMode();
+#endif
 
 #else
 #define CFG_TUH_ENABLED 0


### PR DESCRIPTION
Support switching between USB host and device, needed for implementation of supporting mass storage in RRF.

Requires #3 since USB host support uses tinyUSB.